### PR TITLE
Browser support for models

### DIFF
--- a/models/Language/index.js
+++ b/models/Language/index.js
@@ -1,5 +1,4 @@
-const { dirname } = require('path');
-const __root = dirname(require.main.filename);
+ 
 
 const Transformer = require('../Transformer');
 
@@ -8,7 +7,7 @@ const {
   fetchEmbeddingByName
 } = require('../../utils');
 
-const DEFAULT_DATASET = require(`${__root}/training/datasets/OpenSourceBooks`);
+ 
 
 const NEW_DATASET_NAME = 'New Dataset';
 
@@ -54,11 +53,11 @@ module.exports = async ({
 
       // concatenate and store all reference text
 
-      const text = await combineDocuments(dataset.files);
+      const text = dataset.files
 
       // load the corresponding embedding file
 
-      const embedding = await fetchEmbeddingByName(dataset.name);
+      const embedding = dataset.name
 
       // build training data object
 

--- a/models/Transformer/index.js
+++ b/models/Transformer/index.js
@@ -8,10 +8,9 @@ const {
 
 dotenv.config();
 
-const {
-  RANKING_BATCH_SIZE = 50,
-  MAX_RESPONSE_LENGTH = 240
-} = process.env;
+const RANKING_BATCH_SIZE = 50
+const MAX_RESPONSE_LENGTH = 240
+
 
 // Tokenizer utils. Designed for words and phrases.
 

--- a/models/Transformer/index.js
+++ b/models/Transformer/index.js
@@ -1,12 +1,8 @@
-const { dirname } = require('path');
-const __root = dirname(require.main.filename);
-const fs = require('fs').promises;
 
 const { merge } = require('lodash');
 const dotenv = require('dotenv');
 
 const {
-  combineDocuments,
   isLowerCase
 } = require('../../utils');
 
@@ -340,7 +336,7 @@ module.exports = () => {
 
     console.log(NOTIF_TRAINING);
 
-    trainingText = await combineDocuments(files);
+    trainingText = files
 
     trainingTokens = trainingText.split(' ');
 

--- a/models/Transformer/index.js
+++ b/models/Transformer/index.js
@@ -386,11 +386,7 @@ module.exports = () => {
       console.log(`Token "${nextToken}" ranked: ${embedding[token][nextToken]} (when following ${token}).`);
     });
 
-    const embeddingPath = `${__root}/training/embeddings/${name}.json`;
-
-    await fs.writeFile(
-      embeddingPath, JSON.stringify(embedding)
-    );
+ 
 
     console.log(`Wrote to file: ${embeddingPath}.`);
 
@@ -399,6 +395,8 @@ module.exports = () => {
     );
 
     createEmbedding(embedding);
+
+    return embedding
   };
 
   /**


### PR DESCRIPTION
Closes https://github.com/bennyschmidt/next-token-prediction/issues/1 

@MarketingPip I like what you're working on, but we need to adjust such that it still supports the Node version as-is. One thing that comes to mind is creating a [build script](https://github.com/bennyschmidt/ragdoll-studio/blob/master/ragdoll-react/package.js) like this one that transpiles all Node into browser. That's what I typically do for npms I have released like this example. 

The exports the developer uses are in a `dist/` directory and the `index.js` of the npm exports from that dist. Make sense?

For training data, I'd still like to hear more about your use case. If it's for general autocomplete, we can come up with something in a new Issue. 
